### PR TITLE
Use grep to find the matching tags (fixes #1)

### DIFF
--- a/autoload/asyncomplete/sources/tags.vim
+++ b/autoload/asyncomplete/sources/tags.vim
@@ -56,7 +56,7 @@ function! s:get_tag_files(opt)
     let l:result = []
     for l:tag_file in l:all_tag_files
         let l:file_size = getfsize(l:tag_file)
-        if l:file_size == -1 || l:file_size <= l:max_file_size
+        if l:max_file_size == -1 || l:file_size <= l:max_file_size
             call add(l:result, l:tag_file)
         else
             call asyncomplete#log('ignoring tag file due to large size', l:tag_file, l:file_size)


### PR DESCRIPTION
The asyncomplete-tags is painfully slow for my Symfony projects (because the .tags file is around 30-40mb), which defeats the purpose of asynchronous completion.

To speed up things, grep performs the actual search and saves it to a temporary file.  The file is then read by the completor function, and duplicates are ignored.

The grep command is intercepted before execution (because of the grepprg variable), so I guess it's safe to use (on Windows, the findstr command will be used instead).

I'm deleting the temporary file afterwards, to avoid name collisions ---since tempname() function only guarantees different names for 26 consecutive calls.
