### PR TITLE
Add menu label to tag results (#14)

### DIFF
--- a/autoload/asyncomplete/sources/tags.vim
+++ b/autoload/asyncomplete/sources/tags.vim
@@ -26,7 +26,10 @@ function! asyncomplete#sources#tags#completor(opt, ctx)
 
     if exists("*getcompletion")
       let l:data = getcompletion(l:kw,'tag')
-      call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:data)
+      for l:word in l:data
+        call add(l:matches, {"word": l:word, "dup": 1, "icase": 1, "menu": "[tag]"})
+      endfor
+      call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches)
       return
     endif
 

--- a/autoload/asyncomplete/sources/tags.vim
+++ b/autoload/asyncomplete/sources/tags.vim
@@ -21,7 +21,7 @@ function! asyncomplete#sources#tags#completor(opt, ctx)
         return
     endif
 
-    let l:matches = {}
+    let l:matches = []
     let l:startcol = l:col - l:kwlen
 
     let l:info = { 'counter': len(l:tag_files), 'startcol': l:startcol, 'matches': l:matches, 'opt': a:opt, 'ctx': a:ctx, 'lines': [] }
@@ -52,7 +52,7 @@ function! asyncomplete#sources#tags#completor(opt, ctx)
             call s:lines_to_matches(l:matches, l:lines)
         endfor
 
-        call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, keys(l:matches))
+        call asyncomplete#complete(a:opt['name'], a:ctx, l:startcol, l:matches)
     endif
 endfunction
 
@@ -82,7 +82,7 @@ endfunction
 function! s:complete(info) abort
     let l:opt = a:info['opt']
     let l:ctx = a:info['ctx']
-    call asyncomplete#complete(l:opt['name'], l:ctx, a:info['startcol'], keys(a:info['matches']))
+    call asyncomplete#complete(l:opt['name'], l:ctx, a:info['startcol'], a:info['matches'])
 endfunction
 
 function! s:lines_to_matches(matches, lines) abort
@@ -91,7 +91,8 @@ function! s:lines_to_matches(matches, lines) abort
             let l:splits = split(l:line, "\t")
             if len(l:splits) > 0
                 let l:word = l:splits[0]
-                let a:matches[l:word] = 1
+                let l:type = l:splits[-1]
+                call add(a:matches, {"word": l:word, "menu": "[tag: " . l:type . "]"})
             endif
         endif
     endfor

--- a/autoload/asyncomplete/sources/tags.vim
+++ b/autoload/asyncomplete/sources/tags.vim
@@ -92,7 +92,7 @@ function! s:lines_to_matches(matches, lines) abort
             if len(l:splits) > 0
                 let l:word = l:splits[0]
                 let l:type = l:splits[-1]
-                call add(a:matches, {"word": l:word, "menu": "[tag: " . l:type . "]"})
+                call add(a:matches, {"word": l:word, "dup": 1, "icase": 1, "menu": "[tag: " . l:type . "]"})
             endif
         endif
     endfor


### PR DESCRIPTION
Adds the `[tag]` label to menu items, plus the type of tag the item is; for instance here is a sass `m`ixin and `c`lass:

<img width="191" alt="Screen Shot 2019-06-27 at 11 31 59 AM" src="https://user-images.githubusercontent.com/643417/60279525-3799f680-98cf-11e9-8c25-a69916557f4c.png">


Closes #14