### PR TITLE
Allow tags to be completed if the first typed character is a period

### DIFF
--- a/autoload/asyncomplete/sources/tags.vim
+++ b/autoload/asyncomplete/sources/tags.vim
@@ -17,9 +17,6 @@ function! asyncomplete#sources#tags#completor(opt, ctx)
 
     let l:kw = matchstr(l:typed, '\w\+$')
     let l:kwlen = len(l:kw)
-    if l:kwlen < 1
-        return
-    endif
 
     let l:matches = {}
     let l:startcol = l:col - l:kwlen


### PR DESCRIPTION
I was noticing that if I have a tag like this:

```
header-nav	styles/header-nav.scss	/^.header-nav {$/;"	c
```

And I try to start using it in a Sass file, like this:

```sass
.head
```

The popup menu doesn't appear. Removing the check for the keyword length fixes this, though I'm not sure why, but it seems to have no ill effects.

Notably this length check isn't in [`asyncomplete-neosnippet.vim`](https://github.com/prabirshrestha/asyncomplete-neosnippet.vim/blob/master/autoload/asyncomplete/sources/neosnippet.vim)