### PR TITLE
Use keyword characters for tag matching

### DIFF
--- a/autoload/asyncomplete/sources/tags.vim
+++ b/autoload/asyncomplete/sources/tags.vim
@@ -15,7 +15,7 @@ function! asyncomplete#sources#tags#completor(opt, ctx)
     let l:col = a:ctx['col']
     let l:typed = a:ctx['typed']
 
-    let l:kw = matchstr(l:typed, '\w\+$')
+    let l:kw = matchstr(l:typed, '\k\+$')
     let l:kwlen = len(l:kw)
 
     let l:matches = []


### PR DESCRIPTION
This gives the user more flexibility, as they can define what characters are considered keyword characters